### PR TITLE
Swagger spec for getting population types

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,6 +9,9 @@ info:
 basePath: "/v1"
 schemes:
   - http
+tags:
+  - name: "Public"
+  - name: "Private"
 paths:
   /population-types:
     get:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,30 +9,24 @@ info:
 basePath: "/v1"
 schemes:
   - http
-tags:
-  - name: "hello"
-  - name: "private"
 paths:
-  /hello:
+  /population-types:
     get:
       tags:
-        - hello
-      summary: Example hello world endpoint
-      description: Returns an example payload.
-      produces:
-        - application/json
+        - "Public"
+      summary: "Get all population types relevant to Census"
+      description: "Retrieves a list of cantabular population types for Census"
       responses:
         200:
-          description: OK
+          description: "Json object containing a list of population types for Census"
           schema:
-            $ref: "#/definitions/HelloResponse"
+            $ref: "#/definitions/PopulationTypes"
         500:
-          $ref: '#/responses/InternalError'
-
+          $ref: "#/responses/InternalError"
   /health:
     get:
       tags:
-        - private
+        - "Private"
       summary: "Returns API's health status"
       description: "Returns health status of the API and checks on dependent services"
       produces:
@@ -52,13 +46,6 @@ responses:
     description: "Failed to process the request due to an internal error"
 
 definitions:
-  HelloResponse:
-    type: object
-    properties:
-      message:
-        type: string
-        description: "Message returned by hello world endpoint"
-        example: "Hello, world!"
   Health:
     type: object
     properties:
@@ -100,7 +87,7 @@ definitions:
       checks:
         type: array
         items:
-          $ref: '#/definitions/HealthChecker'
+          $ref: "#/definitions/HealthChecker"
   HealthChecker:
     type: object
     properties:
@@ -128,3 +115,18 @@ definitions:
         type: string
         description: "The last failed health check date and time of the external service"
         example: "2019-09-22T11:48:51.0000001Z"
+  PopulationType:
+    description: "A population type which census data can be retrieved from"
+    type: object
+    properties:
+      name:
+        description: "The name of the population type"
+        type: string
+  PopulationTypes:
+    type: object
+    properties:
+      items:
+        description: "An array of population types"
+        type: array
+        items:
+          $ref: "#/definitions/PopulationType"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,8 +10,8 @@ basePath: "/v1"
 schemes:
   - http
 tags:
-  - name: "Private"
   - name: "Public"
+  - name: "Private"
 securityDefinitions:
   InternalAPIKey:
     name: internal-token
@@ -23,8 +23,11 @@ paths:
     get:
       tags:
         - "Public"
+        - "Private"
       summary: "Get all population types relevant to Census"
       description: "Retrieves a list of cantabular population types for Census"
+      security:
+        - InternalAPIKey: []
       responses:
         200:
           description: "Json object containing a list of population types for Census"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,8 +10,14 @@ basePath: "/v1"
 schemes:
   - http
 tags:
-  - name: "Public"
   - name: "Private"
+  - name: "Public"
+securityDefinitions:
+  InternalAPIKey:
+    name: internal-token
+    description: "API key for internal service calls"
+    in: header
+    type: apiKey
 paths:
   /population-types:
     get:
@@ -24,6 +30,8 @@ paths:
           description: "Json object containing a list of population types for Census"
           schema:
             $ref: "#/definitions/PopulationTypes"
+        401:
+          description: "Unauthorised to fetch"
         500:
           $ref: "#/responses/InternalError"
   /health:


### PR DESCRIPTION
### What

1. Changed tags to match dataset api convention
1. Added security definition for `InternalAPIKey` (as evident on dataset API)
1. Removed hello endpoint
1. Added `population-types` GET endpoint 
1. Added 401 status response as possible for the GET endpoint
1. Added security to the `population-types` endpoint

### How to review

Verify assumptions on swagger structure (especially what security key stuff to use)

### Who can review

@franmoore05 
