### PR TITLE
Add feature flag to enable/disable cantabular health checking

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,10 @@ type Config struct {
 }
 
 type CantabularConfig struct {
-	CantabularURL         string        `envconfig:"CANTABULAR_URL"`
-	CantabularExtURL      string        `envconfig:"CANTABULAR_EXT_API_URL"`
-	DefaultRequestTimeout time.Duration `envconfig:"DEFAULT_REQUEST_TIMEOUT"`
+	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
+	CantabularExtURL             string        `envconfig:"CANTABULAR_EXT_API_URL"`
+	DefaultRequestTimeout        time.Duration `envconfig:"DEFAULT_REQUEST_TIMEOUT"`
+	CantabularHealthcheckEnabled bool          `envconfig:"CANTABULAR_HEALTHCHECK_ENABLED"`
 }
 
 var cfg *Config

--- a/service/service.go
+++ b/service/service.go
@@ -111,7 +111,6 @@ func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 		if svc.Config.CantabularHealthcheckEnabled {
 			if err := svc.HealthCheck.AddCheck("Cantabular client", svc.cantabularClient.Checker); err != nil {
 				return errors.Wrap(err, "error adding check for cantabular client")
-				//return nil
 			}
 		} else {
 			log.Info(ctx, "cantabular health checking is disabled")

--- a/service/service.go
+++ b/service/service.go
@@ -45,7 +45,7 @@ func (svc *Service) Init(ctx context.Context, init Initialiser, cfg *config.Conf
 	svc.buildRoutes(ctx)
 	svc.Server = init.GetHTTPServer(cfg.BindAddr, svc.Router)
 
-	if err = svc.registerCheckers(); err != nil {
+	if err = svc.registerCheckers(ctx); err != nil {
 		return errors.Wrap(err, "unable to register checkers")
 	}
 
@@ -105,11 +105,16 @@ func (svc *Service) Close(ctx context.Context) error {
 	return nil
 }
 
-func (svc *Service) registerCheckers() (err error) {
+func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 
 	if svc.cantabularClient != nil {
-		if err := svc.HealthCheck.AddCheck("Cantabular client", svc.cantabularClient.Checker); err != nil {
-			return errors.Wrap(err, "error adding check for cantabular client")
+		if svc.Config.CantabularHealthcheckEnabled {
+			if err := svc.HealthCheck.AddCheck("Cantabular client", svc.cantabularClient.Checker); err != nil {
+				return errors.Wrap(err, "error adding check for cantabular client")
+				//return nil
+			}
+		} else {
+			log.Info(ctx, "cantabular health checking is disabled")
 		}
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -80,10 +80,7 @@ func TestInit(t *testing.T) {
 					return hcMock, nil
 				}
 				err := svc.Init(ctx, &initialiserMock, &cfgWithCantabularHealthcheckEnabled, testBuildTime, testGitCommit, testVersion)
-
-				Convey("Then service Init succeeds", func() {
-					So(err, ShouldBeNil)
-				})
+				So(err, ShouldBeNil)
 
 				Convey("Then the cantabular healthcheck should be added", func() {
 					cantabularCall := findCantabularClientCheck(hcMock)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -55,16 +55,12 @@ func TestInit(t *testing.T) {
 			initialiserMock.GetHealthCheckFunc = func(cfg *config.Config, buildTime, gitCommit, version string) (service.HealthChecker, error) {
 				return nil, errHealthcheck
 			}
-			// setup (run before each `Convey` at this scope / indentation):
+
 			svc := service.New()
 			err := svc.Init(ctx, &initialiserMock, cfg, testBuildTime, testGitCommit, testVersion)
 
 			Convey("Then service Init fails with an error", func() {
 				So(errors.Is(err, errHealthcheck), ShouldBeTrue)
-			})
-
-			Reset(func() {
-				// This reset is run after each `Convey` at the same scope (indentation)
 			})
 		})
 
@@ -106,14 +102,16 @@ func TestInit(t *testing.T) {
 					return nil
 				},
 			}
+
 			initialiserMock.GetHealthCheckFunc = func(cfg *config.Config, buildTime, gitCommit, version string) (service.HealthChecker, error) {
 				return hcMock, nil
 			}
 
 			Convey("When the service is initialised", func() {
-				// setup (run before each `Convey` at this scope / indentation):
+
 				err := svc.Init(ctx, &initialiserMock, &cfgWithCantabularHealthcheckEnabled, testBuildTime, testGitCommit, testVersion)
 				Convey("Then the cantabular healthcheck error should be included in the returned errors", func() {
+
 					So(strings.Contains(err.Error(), "cantabular client"), ShouldBeTrue)
 				})
 			})
@@ -129,23 +127,19 @@ func TestInit(t *testing.T) {
 				return hcMock, nil
 			}
 
-			// setup (run before each `Convey` at this scope / indentation):
 			err := svc.Init(ctx, &initialiserMock, cfg, testBuildTime, testGitCommit, testVersion)
 
 			Convey("Then service Init succeeds", func() {
+
 				So(err, ShouldBeNil)
 			})
 
 			Convey("Then the cantabular healthcheck should not be added (as the flag is not set)", func() {
+
 				cantabularCall := findCantabularClientCheck(hcMock)
 				So(cantabularCall, ShouldBeNil)
 			})
-
-			Reset(func() {
-				// This reset is run after each `Convey` at the same scope (indentation)
-			})
 		})
-
 	})
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -90,7 +90,8 @@ func TestInit(t *testing.T) {
 					So(cantabularCall.Checker, ShouldNotBeNil)
 
 					checkState := healthcheck.CheckState{}
-					cantabularCall.Checker(ctx, &checkState)
+					err := cantabularCall.Checker(ctx, &checkState)
+					So(err, ShouldBeNil)
 
 					checkerCalls := cantabularClientMock.CheckerCalls()
 					So(checkerCalls[0].State, ShouldPointTo, &checkState)


### PR DESCRIPTION
### What

As a temporary workaround, we've (Team B) been advised to add in a feature flag to enable/disable health checking for cantabular. This will not be needed once the new (AWS-B) environment is established.

### How to review

Verify the new flag is test-driven to support disabling the health check

### Who can review

gophers other than @goofballLogic 