### PR TITLE
5758 - Create an HTTPClient with the DEFAULT_REQUEST_TIMEOUT

### DIFF
--- a/service/initialise.go
+++ b/service/initialise.go
@@ -49,7 +49,7 @@ func (i *Init) GetCantabularClient(cfg config.CantabularConfig) CantabularClient
 			ExtApiHost:     cfg.CantabularExtURL,
 			GraphQLTimeout: cfg.DefaultRequestTimeout,
 		},
-		dphttp.NewClient(),
+		dphttp.ClientWithTimeout(nil, cfg.DefaultRequestTimeout),
 	)
 }
 


### PR DESCRIPTION
### What

The current value of the httpClient is set to 10s.
Creating an HTTPClient with a default timeout will allow us to avoid a
GraphQL connection timeout when requesting data for very large datasets.

The error we are seeing in Kibana:

```
GET /population-types/dummy_data_households/area-types/OACD/areas

{
  "error": "failed to get areas: failed to unmarshal query: failed to post query: failed to read error response body: http: read on closed response body",
  "response": "failed to get areas",
  "status_code": 500
}
```

**Resolves:** [5758](https://trello.com/c/IG3gG3qN/5758-investigate-issue-with-large-file-generation-in-dp-cantabular-csv-exporter)
**Depends on:** https://github.com/ONSdigital/dp-configs/pull/971

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review

ONS developers
