### PR TITLE
fix: change area.Label to area.ID

### DIFF
--- a/features/area.private.feature
+++ b/features/area.private.feature
@@ -43,7 +43,7 @@ Feature: Areas
 
     And I am authorised
 
-    And I GET "/population-types/Example/area-types/City/areas/Belfast"
+    And I GET "/population-types/Example/area-types/City/areas/2"
 
     Then the HTTP status code should be "200"
     Then I should receive the following JSON response:

--- a/features/area.public.feature
+++ b/features/area.public.feature
@@ -45,7 +45,7 @@ Feature: Single Area
         }
         """
 
-        And I GET "/population-types/Example/area-types/City/areas/Liverpool"
+        And I GET "/population-types/Example/area-types/City/areas/1"
         Then I should receive the following JSON response:
           """
           {"area":
@@ -59,7 +59,7 @@ Feature: Single Area
         And the HTTP status code should be "200"
     Scenario: Area Not Found
         When the cantabular area response is bad request
-        And I GET "/population-types/NOTEXIST/area-types/City/areas/Liverpool"
+        And I GET "/population-types/NOTEXIST/area-types/City/areas/1"
         Then the HTTP status code should be "400"
         And I should receive the following JSON response:
         """
@@ -69,7 +69,7 @@ Feature: Single Area
         """
     Scenario: Variable Not Found
         When the cantabular area response is bad request
-        And I GET "/population-types/Example/area-types/NOTEXIST/areas/Liverpool"
+        And I GET "/population-types/Example/area-types/NOTEXIST/areas/1"
         Then the HTTP status code should be "400"
         And I should receive the following JSON response:
         """
@@ -90,7 +90,7 @@ Feature: Single Area
         """
     Scenario: Partials not matched
         When the cantabular area response is not found
-        And I GET "/population-types/Example/area-types/City/areas/Be"
+        And I GET "/population-types/Teaching-Dataset/area-types/Region/areas/E120"
         Then the HTTP status code should be "404"
         And I should receive the following JSON response:
         """

--- a/handler/areas.go
+++ b/handler/areas.go
@@ -177,7 +177,7 @@ func (h *Areas) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	// Stop gap until cantabular returns a better solution
 	// this temporarily stops partial matches
-	if area.Label != cReq.Category {
+	if area.ID != cReq.Category {
 		h.respond.Error(
 			ctx,
 			w,


### PR DESCRIPTION
### What

Fixes GET /population-types/Example/area-types/city/areas/<ID>
to look for id and not label, correcting earlier assumptions 
### How to review

Run make test and make test-component.
Inspect screenshot attached. 


### Who can review

Team B 
![2022-08-18-145526_1920x1200_scrot](https://user-images.githubusercontent.com/24928822/185412318-f3e0091b-8149-4ce8-a1ad-a99d5aadc8b2.png)

