### PR TITLE
5802 Add Pagination Params to JSON response

### DIFF
--- a/contract/area_types.go
+++ b/contract/area_types.go
@@ -7,11 +7,24 @@ type AreaType struct {
 	TotalCount int    `json:"total_count"`
 }
 
+type GetAreaTypesRequest struct {
+	QueryParams
+	PopulationType string
+}
+
 // GetAreaTypesResponse is the response object for GET /area-types
 type GetAreaTypesResponse struct {
+	PaginationResponse
 	AreaTypes []AreaType `json:"area_types"`
 }
 
+type GetAreaTypeParentsRequest struct {
+	QueryParams
+	PopulationType string
+	AreaType       string
+}
+
 type GetAreaTypeParentsResponse struct {
+	PaginationResponse
 	AreaTypes []AreaType `json:"area_types"`
 }

--- a/contract/areas.go
+++ b/contract/areas.go
@@ -34,6 +34,7 @@ func (r *GetAreasRequest) Valid() error {
 
 // GetAreasResponse is the response object for GET /areas
 type GetAreasResponse struct {
+	PaginationResponse
 	Areas []Area `json:"areas"`
 }
 

--- a/contract/population_types.go
+++ b/contract/population_types.go
@@ -17,5 +17,6 @@ func NewPopulationTypes(names []string) PopulationTypes {
 }
 
 type GetPopulationTypesResponse struct {
+	PaginationResponse
 	PopulationTypes
 }

--- a/features/area-type-parents.private.feature
+++ b/features/area-type-parents.private.feature
@@ -13,6 +13,8 @@ Background:
         And the following parents response is available from Cantabular:
         """
         {
+            "count": 1,
+            "total_count": 1,
             "dataset": {
                 "variables": {
                     "edges": [
@@ -47,6 +49,10 @@ Background:
         Then I should receive the following JSON response:
         """
         {
+            "limit": 20,
+            "offset": 0,
+            "count": 1,
+            "total_count": 1,
             "area_types": [
                 {
                     "id": "country",

--- a/features/area-type-parents.public.feature
+++ b/features/area-type-parents.public.feature
@@ -72,6 +72,8 @@ Background:
         Given the following parents response is available from Cantabular:
         """
         {
+            "count": 1,
+            "total_count": 1,
             "dataset": {
                 "variables": {
                     "edges": [
@@ -106,6 +108,10 @@ Background:
         Then I should receive the following JSON response:
         """
         {
+            "limit": 20,
+            "offset": 0,
+            "count": 1,
+            "total_count": 1,
             "area_types": [
                 {
                     "id": "country",
@@ -123,6 +129,8 @@ Background:
         Given the following parents response is available from Cantabular:
         """
         {
+            "count": 1,
+            "total_count": 1,
             "dataset": {
                 "variables": {
                     "edges": [

--- a/features/area-types.private.feature
+++ b/features/area-types.private.feature
@@ -5,6 +5,8 @@ Feature: Area Types
     And the following geography response is available from Cantabular:
     """
     {
+        "count": 2,
+        "total_count": 2,
         "dataset": {
           "variables": {
           "total_count": 2,
@@ -63,6 +65,10 @@ Feature: Area Types
     And I should receive the following JSON response:
     """
     {
+        "limit": 20,
+        "offset": 0,
+        "count": 2,
+        "total_count": 2,
         "area_types":[
           {
                 "id":"city",
@@ -95,6 +101,10 @@ Feature: Area Types
     And I should receive the following JSON response:
     """
     {
+        "limit": 20,
+        "offset": 0,
+        "count": 2,
+        "total_count": 2,
         "area_types":[
           {
                 "id":"city",

--- a/features/area-types.public.feature
+++ b/features/area-types.public.feature
@@ -6,7 +6,8 @@ Feature: Area Types
     And the following geography response is available from Cantabular:
     """
     {
-
+        "count": 2,
+        "total_count": 2,
         "dataset": {
           "variables": {
             "total_count": 2,
@@ -63,6 +64,10 @@ Feature: Area Types
     And I should receive the following JSON response:
     """
     {
+        "limit": 20,
+        "offset": 0,
+        "count": 2,
+        "total_count": 2,
         "area_types":[
           {
                 "id":"city",

--- a/features/areas.public.feature
+++ b/features/areas.public.feature
@@ -17,6 +17,8 @@ Feature: Areas
     When the following area query response is available from Cantabular:
     """
     {
+      "count": 3,
+      "total_count": 3,
       "dataset": {
         "variables": {
           "edges": [
@@ -62,6 +64,10 @@ Feature: Areas
     Then I should receive the following JSON response:
       """
       {
+        "limit": 20,
+        "offset": 0,
+        "count": 3,
+        "total_count": 3,
         "areas": [
           {
             "id": "0",
@@ -88,6 +94,8 @@ Feature: Areas
     And the following area query response is available from Cantabular:
     """
     {
+      "count": 1,
+      "total_count": 1,
       "dataset": {
         "variables": {
           "edges": [
@@ -121,6 +129,10 @@ Feature: Areas
     Then I should receive the following JSON response:
     """
     {
+      "limit": 20,
+      "offset": 0,
+      "count": 1,
+      "total_count": 1,
       "areas": [
         {
           "id": "0",
@@ -139,6 +151,8 @@ Feature: Areas
     And the following area query response is available from Cantabular:
     """
     {
+      "count": 5,
+      "total_count": 5,
       "dataset": {
         "variables": {
           "edges": [
@@ -210,6 +224,10 @@ Feature: Areas
     Then I should receive the following JSON response:
     """
     {
+      "limit": 20,
+      "offset": 0,
+      "count": 5,
+      "total_count": 5,
       "areas": [
         {
           "id": "E",
@@ -285,6 +303,10 @@ Feature: Areas
     Then I should receive the following JSON response:
     """
     {
+      "limit": 20,
+      "offset": 0,
+      "count": 0,
+      "total_count": 0,
       "areas": null
     }
     """

--- a/features/population-types.private.feature
+++ b/features/population-types.private.feature
@@ -23,7 +23,13 @@ Feature: Population types endpoint
 
     Then I should receive the following JSON response:
     """
-    {"items":[{"name": "dataset_1"}, {"name": "dataset_2"}]}
+    {
+        "limit": 2,
+        "count": 2,
+        "total_count": 2,
+        "offset": 0,
+        "items":[{"name": "dataset_1"}, {"name": "dataset_2"}]
+    }
     """
 
   Scenario: If the root population-types endpoint fails, it should return correct errors

--- a/features/population-types.public.feature
+++ b/features/population-types.public.feature
@@ -41,7 +41,13 @@ Feature: Population types endpoint
 
     Then I should receive the following JSON response:
     """
-    {"items":[{"name": "dataset_1"}, {"name": "dataset_2"}]}
+    {
+        "limit": 2,
+        "count": 2,
+        "total_count": 2,
+        "offset": 0,
+        "items":[{"name": "dataset_1"}, {"name": "dataset_2"}]
+    }
     """
 
   Scenario: If the root population-types endpoint fails, it should return correct errors

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.18
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.163.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.163.0 h1:IZ8r82/dTmQtxOI5CKp7ccGcVLh3duf9fJ7/jSdLiRc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.163.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0 h1:m9xfcTqRzmtvpiqSGSq6+9PkGZPxSyggcolF3JIlvn0=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=

--- a/handler/areas.go
+++ b/handler/areas.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-population-types-api/config"
 	"github.com/ONSdigital/dp-population-types-api/contract"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/go-chi/chi/v5"
 
 	"github.com/pkg/errors"
 )
@@ -87,15 +88,24 @@ func (h *Areas) GetAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var resp contract.GetAreasResponse
+	resp := contract.GetAreasResponse{
+		PaginationResponse: contract.PaginationResponse{
+			Limit:  req.Limit,
+			Offset: req.Offset,
+		},
+	}
 
-	for _, variable := range res.Dataset.Variables.Edges {
-		for _, category := range variable.Node.Categories.Search.Edges {
-			resp.Areas = append(resp.Areas, contract.Area{
-				ID:       category.Node.Code,
-				Label:    category.Node.Label,
-				AreaType: variable.Node.Name,
-			})
+	if res != nil {
+		resp.Count = res.Count
+		resp.TotalCount = res.TotalCount
+		for _, variable := range res.Dataset.Variables.Edges {
+			for _, category := range variable.Node.Categories.Search.Edges {
+				resp.Areas = append(resp.Areas, contract.Area{
+					ID:       category.Node.Code,
+					Label:    category.Node.Label,
+					AreaType: variable.Node.Name,
+				})
+			}
 		}
 	}
 

--- a/handler/population_types.go
+++ b/handler/population_types.go
@@ -44,11 +44,13 @@ func (h *PopulationTypes) Get(w http.ResponseWriter, req *http.Request) {
 
 	logData := log.Data{"datasets": ptypes}
 	log.Info(ctx, "population types found", logData)
+	lpt := len(ptypes)
 
 	// return all population types on publishing
 	if h.cfg.EnablePrivateEndpoints {
 		h.respond.JSON(ctx, w, http.StatusOK, contract.GetPopulationTypesResponse{
-			PopulationTypes: contract.NewPopulationTypes(ptypes),
+			PaginationResponse: contract.PaginationResponse{Limit: lpt, Count: lpt, TotalCount: lpt},
+			PopulationTypes:    contract.NewPopulationTypes(ptypes),
 		})
 		return
 	}
@@ -70,7 +72,8 @@ func (h *PopulationTypes) Get(w http.ResponseWriter, req *http.Request) {
 		published = append(published, p)
 	}
 
-	if len(published) == 0 {
+	l := len(published)
+	if l == 0 {
 		h.respond.Error(
 			ctx,
 			w,
@@ -81,7 +84,8 @@ func (h *PopulationTypes) Get(w http.ResponseWriter, req *http.Request) {
 	}
 
 	resp := contract.GetPopulationTypesResponse{
-		PopulationTypes: contract.NewPopulationTypes(published),
+		PaginationResponse: contract.PaginationResponse{Limit: l, Count: l, TotalCount: l},
+		PopulationTypes:    contract.NewPopulationTypes(published),
 	}
 
 	h.respond.JSON(ctx, w, http.StatusOK, resp)

--- a/main.go
+++ b/main.go
@@ -22,13 +22,6 @@ var (
 	GitCommit string
 	// Version represents the version of the service that is running
 	Version string
-
-	// TODO: remove below explainer before commiting
-	/* NOTE: replace the above with the below to run code with for example vscode debugger.
-	   BuildTime string = "1601119818"
-	   GitCommit string = "6584b786caac36b6214ffe04bf62f058d4021538"
-	   Version   string = "v0.1.0"
-	*/
 )
 
 func main() {


### PR DESCRIPTION
### What

Ensure that all API responses that are returned from dp-population-types-api endpoints are following the standard defined [here](https://github.com/ONSdigital/dp-standards/blob/main/API_STANDARDS.md#returning-lists-or-search-results)

[5802 Add Pagination Params to JSON response](https://github.com/ONSdigital/dp-population-types-api/pull/63/commits/a669888b5869822273daad8d46ba326037ab7967)

* Depends on: https://github.com/ONSdigital/dp-api-clients-go/pull/312
* Resolves: https://trello.com/c/7MD0oUPR/5802-bug-fix-count-on-review-page

### How to review

Review this PR in conjunction with https://github.com/ONSdigital/dp-api-clients-go/pull/312

### Who can review

Any ONS developer
