### PR TITLE
5849 Create a 'GetArea' function to perform an exact match

### DIFF
--- a/features/area.private.feature
+++ b/features/area.private.feature
@@ -7,7 +7,7 @@ Feature: Areas
 
     And cantabular api extension is healthy
 
-    When the following area query response is available from Cantabular:
+    When the following GetArea query response is available from Cantabular:
     """
     {
       "dataset": {
@@ -16,17 +16,14 @@ Feature: Areas
             {
               "node": {
                 "categories": {
-                  "search": {
-                    "edges": [
-                      {
-                        "node": {
-                          "code": "2",
-                          "label": "Belfast"
-                        }
+                  "edges": [
+                    {
+                      "node": {
+                        "code": "2",
+                        "label": "Belfast"
                       }
-                    ]
-                  },
-                  "totalCount": 1
+                    }
+                  ]
                 },
                 "label": "City",
                 "name": "city"
@@ -43,8 +40,7 @@ Feature: Areas
 
     And I am authorised
 
-    And I GET "/population-types/Example/area-types/City/areas/2"
-
+    And I GET "/population-types/Example/area-types/city/areas/2"
     Then the HTTP status code should be "200"
     Then I should receive the following JSON response:
     """

--- a/features/area.public.feature
+++ b/features/area.public.feature
@@ -14,16 +14,15 @@ Feature: Single Area
 
     Scenario: Getting area happy
 
-        When the following area query response is available from Cantabular:
+        When the following GetArea query response is available from Cantabular:
         """
         {
-        "dataset": {
-          "variables": {
-            "edges": [
-              {
-                "node": {
-                  "categories": {
-                    "search": {
+           "dataset": {
+            "variables": {
+              "edges": [
+                {
+                  "node": {
+                    "categories": {
                       "edges": [
                         {
                           "node": {
@@ -33,19 +32,17 @@ Feature: Single Area
                         }
                       ]
                     },
-                    "totalCount": 1
-                  },
-                  "label": "City",
-                  "name": "city"
+                    "label": "City",
+                    "name": "city"
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
-        }
         }
         """
 
-        And I GET "/population-types/Example/area-types/City/areas/1"
+        And I GET "/population-types/Example/area-types/city/areas/1"
         Then I should receive the following JSON response:
           """
           {"area":
@@ -59,7 +56,7 @@ Feature: Single Area
         And the HTTP status code should be "200"
     Scenario: Area Not Found
         When the cantabular area response is bad request
-        And I GET "/population-types/NOTEXIST/area-types/City/areas/1"
+        And I GET "/population-types/NOTEXIST/area-types/city/areas/1"
         Then the HTTP status code should be "400"
         And I should receive the following JSON response:
         """
@@ -80,7 +77,7 @@ Feature: Single Area
 
     Scenario: Code Not Found
         When the cantabular area response is not found
-        And I GET "/population-types/Example/area-types/City/areas/NOTEXIST"
+        And I GET "/population-types/Example/area-types/city/areas/NOTEXIST"
         Then the HTTP status code should be "404"
         And I should receive the following JSON response:
         """

--- a/features/mock/cantabular_client.go
+++ b/features/mock/cantabular_client.go
@@ -23,6 +23,7 @@ type CantabularClient struct {
 	GetGeographyDimensionsResponse *cantabular.GetGeographyDimensionsResponse
 	GetDimensionsResponse          *cantabular.GetDimensionsResponse
 	GetAreasResponse               *cantabular.GetAreasResponse
+	GetAreaResponse                *cantabular.GetAreaResponse
 	GetParentsResponse             *cantabular.GetParentsResponse
 	GetCategorisationsResponse     *cantabular.GetCategorisationsResponse
 	ListDatasetsResponse           []string
@@ -105,6 +106,36 @@ func (c *CantabularClient) GetAreas(_ context.Context, _ cantabular.GetAreasRequ
 	}
 
 	return c.GetAreasResponse, nil
+}
+
+func (c *CantabularClient) GetArea(_ context.Context, _ cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error) {
+	if !c.Healthy {
+		return nil, dperrors.New(
+			errors.New("failed to get area"),
+			http.StatusNotFound,
+			log.Data{"errors": map[string]string{"message": "404 Not Found: dataset not loaded in this server"}},
+		)
+	}
+	if c.BadRequest {
+		return nil, dperrors.New(
+			errors.New("bad request"),
+			http.StatusBadRequest,
+			log.Data{"errors": map[string]string{"message": "400 Bad Request: dataset not loaded in this server"}},
+		)
+	}
+	if c.NotFound {
+		return nil, dperrors.New(
+			errors.New("not found"),
+			http.StatusNotFound,
+			log.Data{"errors": map[string]string{"message": "404 Not Found: dataset not loaded in this server"}},
+		)
+	}
+
+	if c.GetAreaResponse == nil {
+		return &cantabular.GetAreaResponse{}, nil
+	}
+
+	return c.GetAreaResponse, nil
 }
 
 func (c *CantabularClient) GetParents(_ context.Context, _ cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error) {

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -21,7 +21,8 @@ func (c *PopulationTypesComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the dp-dataset-api is returning errors for datasets based on "([^"]*)"`, c.datasetClientReturnsErrors)
 	ctx.Step(`^cantabular api extension is healthy`, c.cantabularAPIExtIsHealthy)
 	ctx.Step(`^cantabular server is healthy`, c.cantabularServerIsHealthy)
-	ctx.Step(`^the following area query response is available from Cantabular:$`, c.theFollowingCantabularAreaResponseIsAvailable)
+	ctx.Step(`^the following GetArea query response is available from Cantabular:$`, c.theFollowingCantabularAreaResponseIsAvailable)
+	ctx.Step(`^the following area query response is available from Cantabular:$`, c.theFollowingCantabularAreasResponseIsAvailable)
 	ctx.Step(`^the following parents response is available from Cantabular:$`, c.theFollowingCantabularParentsResponseIsAvailable)
 	ctx.Step(`^the following categorisations response is available from Cantabular:$`, c.theFollowingCantabularCategorisationsResponseIsAvailable)
 
@@ -130,7 +131,7 @@ func (c *PopulationTypesComponent) cantabularServerIsHealthy() error {
 	return nil
 }
 
-func (c *PopulationTypesComponent) theFollowingCantabularAreaResponseIsAvailable(body *godog.DocString) error {
+func (c *PopulationTypesComponent) theFollowingCantabularAreasResponseIsAvailable(body *godog.DocString) error {
 	var resp cantabular.GetAreasResponse
 
 	if err := json.Unmarshal([]byte(body.Content), &resp); err != nil {
@@ -138,6 +139,17 @@ func (c *PopulationTypesComponent) theFollowingCantabularAreaResponseIsAvailable
 	}
 
 	c.fakeCantabular.GetAreasResponse = &resp
+	return nil
+}
+
+func (c *PopulationTypesComponent) theFollowingCantabularAreaResponseIsAvailable(body *godog.DocString) error {
+	var resp cantabular.GetAreaResponse
+
+	if err := json.Unmarshal([]byte(body.Content), &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+
+	c.fakeCantabular.GetAreaResponse = &resp
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.18
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.174.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.175.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,12 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.172.0 h1:Ov+XPMYcGB2vK2ulaZJUfLOeZAffwePY1VR0Y7rdTM4=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.172.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.173.0 h1:chF/ifIVptMDcp5Pm7qi+CoENHfPlD18oJWm7uy1BMw=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.173.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.174.0 h1:k4ShnFK4yihi9Z0dRObZ5edZHUHWxvPCgX5z+Zmq8N8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.174.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.175.0 h1:/3PbXUeWld1K9fD7KmVtV2lEatbB5vsWnaEirzAszOc=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.175.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
@@ -97,12 +93,8 @@ github.com/ONSdigital/log.go/v2 v2.2.0/go.mod h1:i0eFlPDlF1fI4k0/SvXhQIkyQxs676E
 github.com/aws/aws-sdk-go v1.44.91 h1:SRWmuX7PTyhBdLuvSfM7KWrWISJsrRsUPcFDSFduRxY=
 github.com/aws/aws-sdk-go v1.44.91/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chromedp/cdproto v0.0.0-20220725225757-5988d9195a6c h1:Gm+DujZPVAtQNTLhbg5PExjRNfhdTCSMLvJ/pFfY4aY=
-github.com/chromedp/cdproto v0.0.0-20220725225757-5988d9195a6c/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
 github.com/chromedp/cdproto v0.0.0-20220901095120-1a01299a2163 h1:d3i/+z+spo9ieg6L5FWdGmcgvAzsyFNl1vsr68RjzBc=
 github.com/chromedp/cdproto v0.0.0-20220901095120-1a01299a2163/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
-github.com/chromedp/chromedp v0.8.3 h1:UwOY+fhC5Vv3uKgRpnvilCbWs/QPz8ciFwRB0q6pH8k=
-github.com/chromedp/chromedp v0.8.3/go.mod h1:9YfKSJnBNeP77vKecv+DNx2/Tcb+6Gli0d1aZPw/xbk=
 github.com/chromedp/chromedp v0.8.5 h1:HAVg54yQFcn7sg5reVjXtoI1eQaFxhjAjflHACicUFw=
 github.com/chromedp/chromedp v0.8.5/go.mod h1:xal2XY5Di7m/bzlGwtoYpmgIOfDqCakOIVg5OfdkPZ4=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
@@ -268,13 +260,12 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
-github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -291,7 +282,6 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyex
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -359,8 +349,6 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -431,8 +419,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -455,8 +441,6 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -501,9 +485,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220906135438-9e1f76180b77 h1:C1tElbkWrsSkn3IRl1GCW/gETw1TywWIPgwZtXTZbYg=
 golang.org/x/sys v0.0.0-20220906135438-9e1f76180b77/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/handler/areas.go
+++ b/handler/areas.go
@@ -117,11 +117,7 @@ func (h *Areas) GetAll(w http.ResponseWriter, r *http.Request) {
 func (h *Areas) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	cReq := cantabular.GetAreasRequest{
-		PaginationParams: cantabular.PaginationParams{
-			Limit:  1,
-			Offset: 0,
-		},
+	cReq := cantabular.GetAreaRequest{
 		Dataset:  chi.URLParam(r, "population-type"),
 		Variable: chi.URLParam(r, "area-type"),
 		Category: chi.URLParam(r, "area-id"),
@@ -145,7 +141,7 @@ func (h *Areas) Get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	res, err := h.ctblr.GetAreas(ctx, cReq)
+	res, err := h.ctblr.GetArea(ctx, cReq)
 	if err != nil {
 		h.respond.Error(
 			ctx,
@@ -163,7 +159,7 @@ func (h *Areas) Get(w http.ResponseWriter, r *http.Request) {
 	var area *contract.Area
 
 	for _, variable := range res.Dataset.Variables.Edges {
-		for _, category := range variable.Node.Categories.Search.Edges {
+		for _, category := range variable.Node.Categories.Edges {
 			area = &contract.Area{
 				ID:       category.Node.Code,
 				Label:    category.Node.Label,

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -18,6 +18,7 @@ type cantabularClient interface {
 	GetGeographyDimensions(context.Context, cantabular.GetGeographyDimensionsRequest) (*cantabular.GetGeographyDimensionsResponse, error)
 	GetDimensions(context.Context, cantabular.GetDimensionsRequest) (*cantabular.GetDimensionsResponse, error)
 	GetAreas(context.Context, cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error)
+	GetArea(context.Context, cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error)
 	GetParents(context.Context, cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error)
 	GetCategorisations(context.Context, cantabular.GetCategorisationsRequest) (*cantabular.GetCategorisationsResponse, error)
 	StatusCode(error) int

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -46,6 +46,7 @@ type CantabularClient interface {
 	GetDimensions(context.Context, cantabular.GetDimensionsRequest) (*cantabular.GetDimensionsResponse, error)
 	GetGeographyDimensions(ctx context.Context, req cantabular.GetGeographyDimensionsRequest) (*cantabular.GetGeographyDimensionsResponse, error)
 	GetAreas(context.Context, cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error)
+	GetArea(context.Context, cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error)
 	GetParents(context.Context, cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error)
 	GetCategorisations(context.Context, cantabular.GetCategorisationsRequest) (*cantabular.GetCategorisationsResponse, error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error

--- a/service/mock/cantabular_client.go
+++ b/service/mock/cantabular_client.go
@@ -24,6 +24,9 @@ var _ service.CantabularClient = &CantabularClientMock{}
 // 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
 // 				panic("mock out the Checker method")
 // 			},
+// 			GetAreaFunc: func(contextMoqParam context.Context, getAreaRequest cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error) {
+// 				panic("mock out the GetArea method")
+// 			},
 // 			GetAreasFunc: func(contextMoqParam context.Context, getAreasRequest cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error) {
 // 				panic("mock out the GetAreas method")
 // 			},
@@ -55,6 +58,9 @@ type CantabularClientMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *healthcheck.CheckState) error
 
+	// GetAreaFunc mocks the GetArea method.
+	GetAreaFunc func(contextMoqParam context.Context, getAreaRequest cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error)
+
 	// GetAreasFunc mocks the GetAreas method.
 	GetAreasFunc func(contextMoqParam context.Context, getAreasRequest cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error)
 
@@ -84,6 +90,13 @@ type CantabularClientMock struct {
 			Ctx context.Context
 			// State is the state argument value.
 			State *healthcheck.CheckState
+		}
+		// GetArea holds details about calls to the GetArea method.
+		GetArea []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// GetAreaRequest is the getAreaRequest argument value.
+			GetAreaRequest cantabular.GetAreaRequest
 		}
 		// GetAreas holds details about calls to the GetAreas method.
 		GetAreas []struct {
@@ -132,6 +145,7 @@ type CantabularClientMock struct {
 		}
 	}
 	lockChecker                sync.RWMutex
+	lockGetArea                sync.RWMutex
 	lockGetAreas               sync.RWMutex
 	lockGetCategorisations     sync.RWMutex
 	lockGetDimensions          sync.RWMutex
@@ -173,6 +187,41 @@ func (mock *CantabularClientMock) CheckerCalls() []struct {
 	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
 	mock.lockChecker.RUnlock()
+	return calls
+}
+
+// GetArea calls GetAreaFunc.
+func (mock *CantabularClientMock) GetArea(contextMoqParam context.Context, getAreaRequest cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error) {
+	if mock.GetAreaFunc == nil {
+		panic("CantabularClientMock.GetAreaFunc: method is nil but CantabularClient.GetArea was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam context.Context
+		GetAreaRequest  cantabular.GetAreaRequest
+	}{
+		ContextMoqParam: contextMoqParam,
+		GetAreaRequest:  getAreaRequest,
+	}
+	mock.lockGetArea.Lock()
+	mock.calls.GetArea = append(mock.calls.GetArea, callInfo)
+	mock.lockGetArea.Unlock()
+	return mock.GetAreaFunc(contextMoqParam, getAreaRequest)
+}
+
+// GetAreaCalls gets all the calls that were made to GetArea.
+// Check the length with:
+//     len(mockedCantabularClient.GetAreaCalls())
+func (mock *CantabularClientMock) GetAreaCalls() []struct {
+	ContextMoqParam context.Context
+	GetAreaRequest  cantabular.GetAreaRequest
+} {
+	var calls []struct {
+		ContextMoqParam context.Context
+		GetAreaRequest  cantabular.GetAreaRequest
+	}
+	mock.lockGetArea.RLock()
+	calls = mock.calls.GetArea
+	mock.lockGetArea.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Previously the endpoint
```
GET /population-types/{dataset}/area-types/{area-type}/areas/{area-id}
```

was performing a fuzzy search and limiting the results to 1.
Since cantabular api extension  v10.2.1 we can now match exactly an area id.

This is the change to perform an exact match.

Resolves: [5849](https://trello.com/c/epE8FvNN/5849-getarea-endpoint-returning-error-results)
Depends on https://github.com/ONSdigital/dp-api-clients-go/pull/319

### How to review

* Sense check it and ensure tests are :green_circle: 
* Tests should be :green_circle: once [this change](https://github.com/ONSdigital/dp-api-clients-go/pull/319) is released

### Who can review

ONS developers
