### PR TITLE
5858 Create 'GET' parent areas count endpoint

### DIFF
--- a/features/area-type-parents.private.feature
+++ b/features/area-type-parents.private.feature
@@ -82,3 +82,55 @@ Background:
         """
 
         And the HTTP status code should be "404"
+
+    Scenario: Getting parent area count successfully
+
+        Given I am identified as "user@ons.gov.uk"
+
+        And I am authorised
+
+        Given the following parents areas count response is available from Cantabular:
+        """
+        {
+             "Dimension": {
+                "count": 1,
+                "categories": [
+                    {
+                        "code": "E12000001",
+                        "label": "Hartlepool"
+                    }
+                ],
+                "variable": {
+                    "name":  "LADCD",
+                    "label": "Local Authority code"
+                }
+            }
+        }
+        """
+
+        When I GET "/population-types/Example/area-types/city/parents/LADCD/areas-count?areas=E12000001,E12000002"
+
+        Then I should receive the following JSON response:
+        """
+        1
+        """
+
+        And the HTTP status code should be "200"
+
+    Scenario:Getting parent area count but Cantabular returns an error
+        Given I am identified as "user@ons.gov.uk"
+
+        And I am authorised
+
+        And cantabular is unresponsive
+
+        When I GET "/population-types/Example/area-types/city/parents/LADCD/areas-count?areas=E12000001,E12000002"
+
+        Then I should receive the following JSON response:
+        """
+        {
+            "errors": ["failed to get parent areas count"]
+        }
+        """
+
+        And the HTTP status code should be "404"

--- a/features/area-type-parents.public.feature
+++ b/features/area-type-parents.public.feature
@@ -192,3 +192,49 @@ Background:
         """
 
         And the HTTP status code should be "404"
+
+
+    Scenario: Getting parent area count successfully
+
+        Given the following parents areas count response is available from Cantabular:
+        """
+        {
+             "Dimension": {
+                "count": 1,
+                "categories": [
+                    {
+                        "code": "E12000001",
+                        "label": "Hartlepool"
+                    }
+                ],
+                "variable": {
+                    "name":  "LADCD",
+                    "label": "Local Authority code"
+                }
+            }
+        }
+        """
+
+        When I GET "/population-types/Example/area-types/city/parents/LADCD/areas-count?areas=E12000001,E12000002"
+
+        Then I should receive the following JSON response:
+        """
+        1
+        """
+
+        And the HTTP status code should be "200"
+
+    Scenario:Getting parent area count but Cantabular returns an error
+        Given cantabular is unresponsive
+
+        When I GET "/population-types/Example/area-types/city/parents/LADCD/areas-count?areas=E12000001,E12000002"
+
+        Then I should receive the following JSON response:
+        """
+        {
+            "errors": ["failed to get parent areas count"]
+        }
+        """
+
+        And the HTTP status code should be "404"
+

--- a/features/mock/cantabular_client.go
+++ b/features/mock/cantabular_client.go
@@ -25,6 +25,7 @@ type CantabularClient struct {
 	GetAreasResponse               *cantabular.GetAreasResponse
 	GetAreaResponse                *cantabular.GetAreaResponse
 	GetParentsResponse             *cantabular.GetParentsResponse
+	GetParentAreaCountResult       *cantabular.GetParentAreaCountResult
 	GetCategorisationsResponse     *cantabular.GetCategorisationsResponse
 	ListDatasetsResponse           []string
 }
@@ -151,6 +152,17 @@ func (c *CantabularClient) GetParents(_ context.Context, _ cantabular.GetParents
 		)
 	}
 	return c.GetParentsResponse, nil
+}
+func (c *CantabularClient) GetParentAreaCount(_ context.Context, _ cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error) {
+	if !c.Healthy {
+		return nil, dperrors.New(
+			errors.New("test error response"),
+			http.StatusNotFound,
+			nil,
+		)
+	}
+
+	return c.GetParentAreaCountResult, nil
 }
 
 func (c *CantabularClient) GetCategorisations(_ context.Context, _ cantabular.GetCategorisationsRequest) (*cantabular.GetCategorisationsResponse, error) {

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -24,6 +24,7 @@ func (c *PopulationTypesComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the following GetArea query response is available from Cantabular:$`, c.theFollowingCantabularAreaResponseIsAvailable)
 	ctx.Step(`^the following area query response is available from Cantabular:$`, c.theFollowingCantabularAreasResponseIsAvailable)
 	ctx.Step(`^the following parents response is available from Cantabular:$`, c.theFollowingCantabularParentsResponseIsAvailable)
+	ctx.Step(`^the following parents areas count response is available from Cantabular:$`, c.theFollowingCantabularParentAreaCountResponseIsAvailable)
 	ctx.Step(`^the following categorisations response is available from Cantabular:$`, c.theFollowingCantabularCategorisationsResponseIsAvailable)
 
 	ctx.Step(`^the cantabular area response is not found`, c.cantabularIsNotFound)
@@ -161,6 +162,16 @@ func (c *PopulationTypesComponent) theFollowingCantabularParentsResponseIsAvaila
 	}
 
 	c.fakeCantabular.GetParentsResponse = &resp
+	return nil
+}
+
+func (c *PopulationTypesComponent) theFollowingCantabularParentAreaCountResponseIsAvailable(body *godog.DocString) error {
+	var resp cantabular.GetParentAreaCountResult
+	resp.Dimension.Count = 1
+	if err := json.Unmarshal([]byte(body.Content), &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	c.fakeCantabular.GetParentAreaCountResult = &resp
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.178.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
-	github.com/ONSdigital/dp-component-test v0.7.0
+	github.com/ONSdigital/dp-component-test v0.8.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.4.0
@@ -31,7 +31,7 @@ require (
 	github.com/ONSdigital/dp-rchttp v1.0.0 // indirect
 	github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e // indirect
 	github.com/aws/aws-sdk-go v1.44.96 // indirect
-	github.com/chromedp/cdproto v0.0.0-20220908234607-11c39c58d330 // indirect
+	github.com/chromedp/cdproto v0.0.0-20220912224519-0eb792ccf14a // indirect
 	github.com/chromedp/chromedp v0.8.5 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
@@ -41,7 +41,7 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect
-	github.com/gofrs/uuid v4.2.0+incompatible // indirect
+	github.com/gofrs/uuid v4.3.0+incompatible // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -70,9 +70,9 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
-	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 // indirect
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect
-	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
+	golang.org/x/sys v0.0.0-20220913153101-76c7481b5158 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc5
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
 github.com/ONSdigital/dp-component-test v0.7.0/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
+github.com/ONSdigital/dp-component-test v0.8.0 h1:bXl+doGHCyL7cFqSZz3fBqFhhrQxqc6IG7VKuhqKwN4=
+github.com/ONSdigital/dp-component-test v0.8.0/go.mod h1:oWFMzP7C+KQXmbj2rnx1rjbwcuxPaN73imrtQn0qzJo=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -97,6 +99,8 @@ github.com/aws/aws-sdk-go v1.44.96/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chromedp/cdproto v0.0.0-20220908234607-11c39c58d330 h1:MnPpJleRPl2SBJJfonTg4Ok6/GfWjbPASbmRE58ktu8=
 github.com/chromedp/cdproto v0.0.0-20220908234607-11c39c58d330/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
+github.com/chromedp/cdproto v0.0.0-20220912224519-0eb792ccf14a h1:JW8D0n0cGdFJsVntEX+OBPdVqbE/J73+g47YWACI15M=
+github.com/chromedp/cdproto v0.0.0-20220912224519-0eb792ccf14a/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
 github.com/chromedp/chromedp v0.8.5 h1:HAVg54yQFcn7sg5reVjXtoI1eQaFxhjAjflHACicUFw=
 github.com/chromedp/chromedp v0.8.5/go.mod h1:xal2XY5Di7m/bzlGwtoYpmgIOfDqCakOIVg5OfdkPZ4=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
@@ -148,6 +152,8 @@ github.com/gobwas/ws v1.1.0/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v4.3.0+incompatible h1:CaSVZxm5B+7o45rtab4jC2G37WGYX1zQfuU2i6DSvnc=
+github.com/gofrs/uuid v4.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -423,6 +429,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 h1:1WGATo9HAhkWMbfyuVU0tEFP88OIkUvwaHFveQPvzCQ=
 golang.org/x/net v0.0.0-20220907135653-1e95f45603a7/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -491,6 +499,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220913153101-76c7481b5158 h1:XQphkCZeKYaMRSo28HqvvNYuLOoM5CIOOvTZfthvTgI=
+golang.org/x/sys v0.0.0-20220913153101-76c7481b5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -20,6 +20,7 @@ type cantabularClient interface {
 	GetAreas(context.Context, cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error)
 	GetArea(context.Context, cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error)
 	GetParents(context.Context, cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error)
+	GetParentAreaCount(context.Context, cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error)
 	GetCategorisations(context.Context, cantabular.GetCategorisationsRequest) (*cantabular.GetCategorisationsResponse, error)
 	StatusCode(error) int
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -48,6 +48,7 @@ type CantabularClient interface {
 	GetAreas(context.Context, cantabular.GetAreasRequest) (*cantabular.GetAreasResponse, error)
 	GetArea(context.Context, cantabular.GetAreaRequest) (*cantabular.GetAreaResponse, error)
 	GetParents(context.Context, cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error)
+	GetParentAreaCount(ctx context.Context, req cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error)
 	GetCategorisations(context.Context, cantabular.GetCategorisationsRequest) (*cantabular.GetCategorisationsResponse, error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	CheckerAPIExt(ctx context.Context, state *healthcheck.CheckState) error

--- a/service/mock/cantabular_client.go
+++ b/service/mock/cantabular_client.go
@@ -42,6 +42,9 @@ var _ service.CantabularClient = &CantabularClientMock{}
 // 			GetGeographyDimensionsFunc: func(ctx context.Context, req cantabular.GetGeographyDimensionsRequest) (*cantabular.GetGeographyDimensionsResponse, error) {
 // 				panic("mock out the GetGeographyDimensions method")
 // 			},
+// 			GetParentAreaCountFunc: func(ctx context.Context, req cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error) {
+// 				panic("mock out the GetParentAreaCount method")
+// 			},
 // 			GetParentsFunc: func(contextMoqParam context.Context, getParentsRequest cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error) {
 // 				panic("mock out the GetParents method")
 // 			},
@@ -78,6 +81,9 @@ type CantabularClientMock struct {
 
 	// GetGeographyDimensionsFunc mocks the GetGeographyDimensions method.
 	GetGeographyDimensionsFunc func(ctx context.Context, req cantabular.GetGeographyDimensionsRequest) (*cantabular.GetGeographyDimensionsResponse, error)
+
+	// GetParentAreaCountFunc mocks the GetParentAreaCount method.
+	GetParentAreaCountFunc func(ctx context.Context, req cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error)
 
 	// GetParentsFunc mocks the GetParents method.
 	GetParentsFunc func(contextMoqParam context.Context, getParentsRequest cantabular.GetParentsRequest) (*cantabular.GetParentsResponse, error)
@@ -139,6 +145,13 @@ type CantabularClientMock struct {
 			// Req is the req argument value.
 			Req cantabular.GetGeographyDimensionsRequest
 		}
+		// GetParentAreaCount holds details about calls to the GetParentAreaCount method.
+		GetParentAreaCount []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Req is the req argument value.
+			Req cantabular.GetParentAreaCountRequest
+		}
 		// GetParents holds details about calls to the GetParents method.
 		GetParents []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
@@ -164,6 +177,7 @@ type CantabularClientMock struct {
 	lockGetCategorisations     sync.RWMutex
 	lockGetDimensions          sync.RWMutex
 	lockGetGeographyDimensions sync.RWMutex
+	lockGetParentAreaCount     sync.RWMutex
 	lockGetParents             sync.RWMutex
 	lockListDatasets           sync.RWMutex
 	lockStatusCode             sync.RWMutex
@@ -411,6 +425,41 @@ func (mock *CantabularClientMock) GetGeographyDimensionsCalls() []struct {
 	mock.lockGetGeographyDimensions.RLock()
 	calls = mock.calls.GetGeographyDimensions
 	mock.lockGetGeographyDimensions.RUnlock()
+	return calls
+}
+
+// GetParentAreaCount calls GetParentAreaCountFunc.
+func (mock *CantabularClientMock) GetParentAreaCount(ctx context.Context, req cantabular.GetParentAreaCountRequest) (*cantabular.GetParentAreaCountResult, error) {
+	if mock.GetParentAreaCountFunc == nil {
+		panic("CantabularClientMock.GetParentAreaCountFunc: method is nil but CantabularClient.GetParentAreaCount was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Req cantabular.GetParentAreaCountRequest
+	}{
+		Ctx: ctx,
+		Req: req,
+	}
+	mock.lockGetParentAreaCount.Lock()
+	mock.calls.GetParentAreaCount = append(mock.calls.GetParentAreaCount, callInfo)
+	mock.lockGetParentAreaCount.Unlock()
+	return mock.GetParentAreaCountFunc(ctx, req)
+}
+
+// GetParentAreaCountCalls gets all the calls that were made to GetParentAreaCount.
+// Check the length with:
+//     len(mockedCantabularClient.GetParentAreaCountCalls())
+func (mock *CantabularClientMock) GetParentAreaCountCalls() []struct {
+	Ctx context.Context
+	Req cantabular.GetParentAreaCountRequest
+} {
+	var calls []struct {
+		Ctx context.Context
+		Req cantabular.GetParentAreaCountRequest
+	}
+	mock.lockGetParentAreaCount.RLock()
+	calls = mock.calls.GetParentAreaCount
+	mock.lockGetParentAreaCount.RUnlock()
 	return calls
 }
 

--- a/service/routes.go
+++ b/service/routes.go
@@ -56,6 +56,7 @@ func (svc *Service) publicEndpoints(ctx context.Context) {
 	)
 	svc.Router.Get("/population-types/{population-type}/area-types", areaTypes.Get)
 	svc.Router.Get("/population-types/{population-type}/area-types/{area-type}/parents", areaTypes.GetParents)
+	svc.Router.Get("/population-types/{population-type}/area-types/{area-type}/parents/{parent-area-type}/areas-count", areaTypes.GetParentAreaCount)
 
 	areas := handler.NewAreas(
 		svc.Config,
@@ -106,6 +107,7 @@ func (svc *Service) privateEndpoints(ctx context.Context) {
 	)
 	r.Get("/population-types/{population-type}/area-types", areaTypes.Get)
 	r.Get("/population-types/{population-type}/area-types/{area-type}/parents", areaTypes.GetParents)
+	r.Get("/population-types/{population-type}/area-types/{area-type}/parents/{parent-area-type}/areas-count", areaTypes.GetParentAreaCount)
 
 	areas := handler.NewAreas(
 		svc.Config,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -179,7 +179,7 @@ paths:
           description: "parent area types returned successfully"
           schema:
             $ref: '#/definitions/GetAreaTypesResponse'
-  /population-types/{population-type}/area-type/{area-type}/parents/{parent-area-type}/areas-count:
+  /population-types/{population-type}/area-types/{area-type}/parents/{parent-area-type}/areas-count:
     get:
       tags:
         - "Private"


### PR DESCRIPTION
### What

A new GET endpoint is needed to retrieve the count of areas within the larger area-type.

URI would be
```
/population-types/{population-type}/area-type/{area-type}/parents/{parent-area-type}/areas-count?areas=put,your,list,of,areas,here.
```

This should just return an integer of the count of the number of areas within the original area type within the larger area.

Resolves: [5858](https://trello.com/c/oDyIu8hU/5858-create-endpoint-to-get-the-count-of-areas-within-the-larger-area-type)

### How to review

* Sense check it
* Ensure tests are :green_circle: 
* Checkout the branch and bring the stack up locally.

### Who can review

Any ONS developer
