### PR TITLE
fix: add return in when lists are empty

### DIFF
--- a/handler/dimensions.go
+++ b/handler/dimensions.go
@@ -227,10 +227,11 @@ func (h *Dimensions) GetBaseVariable(w http.ResponseWriter, r *http.Request) {
 			len(res.Dataset.Variables.Edges[0].Node.MapFrom) == 0 ||
 			len(res.Dataset.Variables.Edges[0].Node.MapFrom[0].Edges) == 0 {
 			h.respond.Error(ctx, w, http.StatusInternalServerError, &Error{
-				err:     errors.Wrap(err, "failed to get base variable"),
-				message: "cantabular returned unexpected empty list",
+				err:     errors.Wrap(err, "cantabular returned unexpected empty list"),
+				message: "failed to get base variable",
 				logData: logData,
 			})
+			return
 		}
 		resp.Name = res.Dataset.Variables.Edges[0].Node.MapFrom[0].Edges[0].Node.Name
 		resp.Label = res.Dataset.Variables.Edges[0].Node.MapFrom[0].Edges[0].Node.Label


### PR DESCRIPTION
`###` What

Previous work on the /base variable endpoint revealed a small but that hit a nilpointer condition. 
This is because a return method was missing in one of the clauses. 
This has been added now

### How to review

check the placement of the return. 


### Who can review

team b
