### PR TITLE
paginate published items

### DIFF
--- a/handler/population_types.go
+++ b/handler/population_types.go
@@ -82,7 +82,7 @@ func (h *PopulationTypes) Get(w http.ResponseWriter, req *http.Request) {
 		published = append(published, p)
 	}
 
-	paginated = r.Paginate(ptypes)
+	paginated = r.Paginate(published)
 
 	l := len(published)
 	if l == 0 {


### PR DESCRIPTION
### What

Use published items instead of all items for public call to GET /population-types.

This was already the case but was accidentally changes when manual pagination was implemented.

### How to review

Check change makes sense

### Who can review

Anyone