### PR TITLE
adding geography hierarchy order to GET area-types and area-type parents

### DIFF
--- a/contract/area_types.go
+++ b/contract/area_types.go
@@ -2,10 +2,11 @@ package contract
 
 // AreaType is an area-type model with ID and Label
 type AreaType struct {
-	ID          string `json:"id"`
-	Label       string `json:"label"`
-	Description string `json:"description"`
-	TotalCount  int    `json:"total_count"`
+	ID                      string `json:"id"`
+	Label                   string `json:"label"`
+	Description             string `json:"description"`
+	TotalCount              int    `json:"total_count"`
+	GeographyHierarchyOrder int    `json:"geography_hierarchy_order"`
 }
 
 type GetAreaTypesRequest struct {

--- a/contract/area_types.go
+++ b/contract/area_types.go
@@ -2,11 +2,11 @@ package contract
 
 // AreaType is an area-type model with ID and Label
 type AreaType struct {
-	ID                      string `json:"id"`
-	Label                   string `json:"label"`
-	Description             string `json:"description"`
-	TotalCount              int    `json:"total_count"`
-	GeographyHierarchyOrder int    `json:"geography_hierarchy_order"`
+	ID             string `json:"id"`
+	Label          string `json:"label"`
+	Description    string `json:"description"`
+	TotalCount     int    `json:"total_count"`
+	HierarchyOrder int    `json:"hierarchy_order"`
 }
 
 type GetAreaTypesRequest struct {

--- a/features/area-type-parents.private.feature
+++ b/features/area-type-parents.private.feature
@@ -64,7 +64,7 @@ Background:
                     "label": "Country",
                     "description": "",
                     "total_count": 2,
-                    "geography_hierarchy_order": 100
+                    "hierarchy_order": 100
                 }
             ]
         }

--- a/features/area-type-parents.private.feature
+++ b/features/area-type-parents.private.feature
@@ -30,7 +30,12 @@ Background:
                                                 "label": "Country",
                                                 "categories": {
                                                     "totalCount": 2
-                                                }
+                                                },
+                                                 "meta": {
+                                                   "ONS_Variable": {
+                                                      "Geography_Hierarchy_Order": "100"
+                                                    }
+                                                 }
                                             }
                                         }
                                     ],
@@ -58,7 +63,8 @@ Background:
                     "id": "country",
                     "label": "Country",
                     "description": "",
-                    "total_count": 2
+                    "total_count": 2,
+                    "geography_hierarchy_order": 100
                 }
             ]
         }

--- a/features/area-type-parents.public.feature
+++ b/features/area-type-parents.public.feature
@@ -125,7 +125,7 @@ Background:
                     "label": "Country",
                     "description": "",
                     "total_count": 2,
-                    "geography_hierarchy_order": 100
+                    "hierarchy_order": 100
                 }
             ]
         }

--- a/features/area-type-parents.public.feature
+++ b/features/area-type-parents.public.feature
@@ -91,7 +91,12 @@ Background:
                                                 "description":  "test",
                                                 "categories": {
                                                     "totalCount": 2
-                                                }
+                                                },
+                                                 "meta": {
+                                                   "ONS_Variable": {
+                                                      "Geography_Hierarchy_Order": "100"
+                                                    }
+                                                 }
                                             }
                                         }
                                     ],
@@ -119,7 +124,8 @@ Background:
                     "id": "country",
                     "label": "Country",
                     "description": "",
-                    "total_count": 2
+                    "total_count": 2,
+                    "geography_hierarchy_order": 100
                 }
             ]
         }
@@ -151,7 +157,12 @@ Background:
                                                 "description":  "test",
                                                 "categories": {
                                                     "totalCount": 2
-                                                }
+                                                },
+                                                "meta": {
+                                                   "ONS_Variable": {
+                                                      "Geography_Hierarchy_Order": "100"
+                                                    }
+                                                 }
                                             }
                                         }
                                     ],

--- a/features/area-types.private.feature
+++ b/features/area-types.private.feature
@@ -88,14 +88,14 @@ Feature: Area Types
                 "label":"Country",
                 "description": "test",
                 "total_count": 2,
-                "geography_hierarchy_order": 200
+                "hierarchy_order": 200
           },
           {
                 "id":"city",
                 "label":"City",
                 "description": "test",
                 "total_count": 3,
-                "geography_hierarchy_order": 100
+                "hierarchy_order": 100
           }
         ]
     }
@@ -129,14 +129,14 @@ Feature: Area Types
                 "label":"Country",
                 "description": "test",
                 "total_count": 2,
-                "geography_hierarchy_order": 200
+                "hierarchy_order": 200
           },
           {
                 "id":"city",
                 "label":"City",
                 "description": "test",
                 "total_count": 3,
-                "geography_hierarchy_order": 100
+                "hierarchy_order": 100
           }
         ]
     }

--- a/features/area-types.private.feature
+++ b/features/area-types.private.feature
@@ -18,7 +18,12 @@ Feature: Area Types
                    "description":  "test",
                    "categories": {
                      "totalCount": 3
-                  }
+                  },
+                  "meta": {
+                    "ONS_Variable": {
+                      "Geography_Hierarchy_Order": "100"
+                     }
+                   }
                 }
               },
               {
@@ -42,7 +47,12 @@ Feature: Area Types
                          }
                        ]
                      }
-                   ]
+                   ],
+                   "meta": {
+                     "ONS_Variable": {
+                       "Geography_Hierarchy_Order": "200"
+                     }
+                   }
                  }
                }
              ]
@@ -77,13 +87,15 @@ Feature: Area Types
                 "id":"country",
                 "label":"Country",
                 "description": "test",
-                "total_count": 2
+                "total_count": 2,
+                "geography_hierarchy_order": 200
           },
           {
                 "id":"city",
                 "label":"City",
                 "description": "test",
-                "total_count": 3
+                "total_count": 3,
+                "geography_hierarchy_order": 100
           }
         ]
     }
@@ -116,13 +128,15 @@ Feature: Area Types
                 "id":"country",
                 "label":"Country",
                 "description": "test",
-                "total_count": 2
+                "total_count": 2,
+                "geography_hierarchy_order": 200
           },
           {
                 "id":"city",
                 "label":"City",
                 "description": "test",
-                "total_count": 3
+                "total_count": 3,
+                "geography_hierarchy_order": 100
           }
         ]
     }

--- a/features/area-types.public.feature
+++ b/features/area-types.public.feature
@@ -19,7 +19,12 @@ Feature: Area Types
                     "description":  "test",
                     "categories": {
                       "totalCount": 348
-                    }
+                    },
+                    "meta": {
+                    "ONS_Variable": {
+                      "Geography_Hierarchy_Order": "200"
+                     }
+                   }
                   }
                 },
                 {
@@ -29,7 +34,12 @@ Feature: Area Types
                     "description":  "test",
                     "categories": {
                       "totalCount": 2
-                    }
+                    },
+                    "meta": {
+                    "ONS_Variable": {
+                      "Geography_Hierarchy_Order": "300"
+                     }
+                   }
                   }
                 },
                 {
@@ -52,7 +62,12 @@ Feature: Area Types
                           }
                         ]
                       }
-                    ]
+                    ],
+                  "meta": {
+                    "ONS_Variable": {
+                      "Geography_Hierarchy_Order": "100"
+                     }
+                   }
                   }
                 }
               ]
@@ -86,19 +101,22 @@ Feature: Area Types
                 "id":"city",
                 "label":"City",
                 "description": "test",
-                "total_count": 2
-          },
-          {
-                "id":"country",
-                "label":"Country",
-                "description": "test",
-                "total_count": 3
+                "total_count": 2,
+                "geography_hierarchy_order": 300
           },
           {
                 "id":"region",
                 "label":"Region",
                 "description": "test",
-                "total_count": 348
+                "total_count": 348,
+                "geography_hierarchy_order": 200
+          },
+          {
+                "id":"country",
+                "label":"Country",
+                "description": "test",
+                "total_count": 3,
+                "geography_hierarchy_order": 100
           }
         ]
     }

--- a/features/area-types.public.feature
+++ b/features/area-types.public.feature
@@ -102,21 +102,21 @@ Feature: Area Types
                 "label":"City",
                 "description": "test",
                 "total_count": 2,
-                "geography_hierarchy_order": 300
+                "hierarchy_order": 300
           },
           {
                 "id":"region",
                 "label":"Region",
                 "description": "test",
                 "total_count": 348,
-                "geography_hierarchy_order": 200
+                "hierarchy_order": 200
           },
           {
                 "id":"country",
                 "label":"Country",
                 "description": "test",
                 "total_count": 3,
-                "geography_hierarchy_order": 100
+                "hierarchy_order": 100
           }
         ]
     }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.19
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.209.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.211.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.9.0
 	github.com/ONSdigital/dp-healthcheck v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.209.0 h1:4/OFYAD8EAPYREAegptxYOgnznz9nDwclctdPMLJzGc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.209.0/go.mod h1:JhWrjETosIKYjbLoa3d19QJlKv7dx+/+x09qg355Rxg=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.211.0 h1:uAojkbULUI4ogMfrhLLHYYIf/V/ej4eAm9Ezr1OpO6A=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.211.0/go.mod h1:JhWrjETosIKYjbLoa3d19QJlKv7dx+/+x09qg355Rxg=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.9.0 h1:DfSvL1CKrZ4Jm/WqNLw27DtOcn2fmPI6KNx9zaFYgCo=

--- a/handler/area_types.go
+++ b/handler/area_types.go
@@ -97,28 +97,29 @@ func (h *AreaTypes) Get(w http.ResponseWriter, r *http.Request) {
 		resp.TotalCount = res.TotalCount
 
 		for _, edge := range res.Dataset.Variables.Edges {
-
 			i := 0
 			if len(edge.Node.Meta.ONSVariable.GeographyHierarchyOrder) > 0 {
 				i, err = strconv.Atoi(edge.Node.Meta.ONSVariable.GeographyHierarchyOrder)
 				if err != nil {
-					h.respond.Error(ctx, w, http.StatusBadRequest, &Error{
-						err: errors.Wrap(err, "unable to cast geography order field to int"),
+					h.respond.Error(ctx, w, http.StatusInternalServerError, &Error{
+						err:     errors.Wrap(err, "failed to get geography dimensions"),
+						message: "failed to convert geography order",
+						logData: logData,
 					})
 					return
 				}
 			}
 
 			resp.AreaTypes = append(resp.AreaTypes, contract.AreaType{
-				ID:                      edge.Node.Name,
-				Label:                   edge.Node.Label,
-				Description:             edge.Node.Description,
-				TotalCount:              edge.Node.Categories.TotalCount,
-				GeographyHierarchyOrder: i,
+				ID:             edge.Node.Name,
+				Label:          edge.Node.Label,
+				Description:    edge.Node.Description,
+				TotalCount:     edge.Node.Categories.TotalCount,
+				HierarchyOrder: i,
 			})
 		}
 		sort.Slice(resp.AreaTypes, func(i, j int) bool {
-			return resp.AreaTypes[i].GeographyHierarchyOrder > resp.AreaTypes[j].GeographyHierarchyOrder
+			return resp.AreaTypes[i].HierarchyOrder > resp.AreaTypes[j].HierarchyOrder
 		})
 	}
 
@@ -198,28 +199,29 @@ func (h *AreaTypes) GetParents(w http.ResponseWriter, r *http.Request) {
 	resp.Count = res.Count
 	resp.TotalCount = res.TotalCount
 	for _, e := range res.Dataset.Variables.Edges[0].Node.IsSourceOf.Edges {
-
 		i := 0
 		if len(e.Node.Meta.ONSVariable.GeographyHierarchyOrder) > 0 {
 			i, err = strconv.Atoi(e.Node.Meta.ONSVariable.GeographyHierarchyOrder)
 			if err != nil {
-				h.respond.Error(ctx, w, http.StatusBadRequest, &Error{
-					err: errors.Wrap(err, "unable to cast geography order field to int"),
+				h.respond.Error(ctx, w, http.StatusInternalServerError, &Error{
+					err:     errors.Wrap(err, "failed to get geography dimensions"),
+					message: "failed to convert geography order",
+					logData: logData,
 				})
 				return
 			}
 		}
 
 		resp.AreaTypes = append(resp.AreaTypes, contract.AreaType{
-			ID:                      e.Node.Name,
-			Label:                   e.Node.Label,
-			TotalCount:              e.Node.Categories.TotalCount,
-			GeographyHierarchyOrder: i,
+			ID:             e.Node.Name,
+			Label:          e.Node.Label,
+			TotalCount:     e.Node.Categories.TotalCount,
+			HierarchyOrder: i,
 		})
 	}
 
 	sort.Slice(resp.AreaTypes, func(i, j int) bool {
-		return resp.AreaTypes[i].GeographyHierarchyOrder > resp.AreaTypes[j].GeographyHierarchyOrder
+		return resp.AreaTypes[i].HierarchyOrder > resp.AreaTypes[j].HierarchyOrder
 	})
 
 	h.respond.JSON(ctx, w, http.StatusOK, resp)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -476,6 +476,9 @@ definitions:
       description:
         type: string
         example: "National code definition for Census 2021"
+      geography_hierarchy_order:
+        type: integer
+        example: "1200"
       total_count:
         type: integer
         example: "2"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -476,7 +476,7 @@ definitions:
       description:
         type: string
         example: "National code definition for Census 2021"
-      geography_hierarchy_order:
+      hierarchy_order:
         type: integer
         example: "1200"
       total_count:


### PR DESCRIPTION
### What

Added geography_hierarchy_order to the response for GET /area-types and GET /area-types/{area-type}/parents.  The response for GET /area-types has also been ordered using this value.
This is required for the addition of the ward level geography.

### How to review

Ensure the tests pass and the changes make sense.

### Who can review

Anyone.
