### PR TITLE
Release/1.26.0

### DIFF
--- a/contract/dimensions.go
+++ b/contract/dimensions.go
@@ -58,15 +58,16 @@ type GetCategorisationsResponse struct {
 }
 
 type Category struct {
-	Id                   string              `json:"id"`
-	Label                string              `json:"label"`
-	Categories           []DimensionCategory `json:"categories"`
-	QualityStatementText string              `json:"quality_statement_text"`
+	Id                    string              `json:"id"`
+	Label                 string              `json:"label"`
+	Categories            []DimensionCategory `json:"categories"`
+	QualityStatementText  string              `json:"quality_statement_text"`
+	DefaultCategorisation bool                `json:"default_categorisation"`
 }
 
 type DimensionCategory struct {
-	ID                   string `json:"id"`
-	Label                string `json:"label"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
 }
 
 type GetBaseVariableRequest struct {

--- a/features/categorisations.private.feature
+++ b/features/categorisations.private.feature
@@ -36,6 +36,7 @@ Background:
                                             },
                                             "label": "label 2",
                                             "meta": {
+                                                "Default_Classification_Flag": "Y",
                                                 "ONS_Variable": {
                                                     "Quality_Statement_Text": "quality statement 1"
                                                 }
@@ -68,6 +69,7 @@ Background:
                     "id": "name 1",
                     "label": "label 2",
                     "quality_statement_text":"quality statement 1",
+                    "default_categorisation": true,
                     "categories": [{
                          "id": "code 1",
                          "label": "label 1"

--- a/features/categorisations.public.feature
+++ b/features/categorisations.public.feature
@@ -30,6 +30,7 @@ Background:
                         },
                         "label": "label 2",
                         "meta": {
+                          "Default_Classification_Flag": "Y",
                           "ONS_Variable": {
                             "Quality_Statement_Text": "quality statement"
                           }
@@ -72,6 +73,7 @@ Background:
           "id": "name 1",
           "label": "label 2",
           "quality_statement_text": "quality statement",
+          "default_categorisation": true,
           "categories": [{
             "id": "code 1",
             "label": "label 1"

--- a/features/census-observations.public.feature
+++ b/features/census-observations.public.feature
@@ -14,6 +14,17 @@ Scenario: Getting census observations successfully
 
     Given census observations endpoint is enabled
 
+    And the following dataset type is available from Cantabular:
+    """
+    {
+        "data": {
+            "dataset": {
+            "type": "microdata"
+            }
+        }
+    }
+    """
+
     And the following census observations response is available from Cantabular:
     """
     {
@@ -235,6 +246,36 @@ Given the following census observations response is available from Cantabular:
     
     And the cantabular area response is bad request
 
+    And the following dataset type is available from Cantabular:
+    """
+    {
+        "data": {
+            "dataset": {
+            "type": "microdata"
+            }
+        }
+    }
+    """
+    And census observations endpoint is enabled
+
+    When I GET "/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"
+
+    Then the HTTP status code should be "400"
+
+
+Scenario: Getting census observations dataset error
+
+Given the following dataset type is available from Cantabular:
+    """
+    {
+        "data": {
+            "dataset": {
+            "type": "not-microdata"
+            }
+        }
+    }
+    """
+
     And census observations endpoint is enabled
 
     When I GET "/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"
@@ -243,17 +284,29 @@ Given the following census observations response is available from Cantabular:
 
 Scenario: Getting More Than 5 errors:
     Given the following census observations response is available from Cantabular:
-       """
-       {
+    """
+    {
         "dataset": {
-          "table": {
+            "table": {
             "dimensions": null,
             "error": "Maximum variables in query is 5",
             "values": null
-          }
+            }
         }
-       }
-       """
+    }
+    """
+
+    And the following dataset type is available from Cantabular:
+    """
+    {
+        "data": {
+            "dataset": {
+            "type": "microdata"
+            }
+        }
+    }
+    """
+    
     And census observations endpoint is enabled
 
     When I GET "/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"

--- a/features/census-observations.public.feature
+++ b/features/census-observations.public.feature
@@ -232,9 +232,31 @@ Given the following census observations response is available from Cantabular:
         }
     }
     """
-    
+
     And census observations endpoint is enabled
 
     When I GET "/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"
 
     Then the HTTP status code should be "400"
+
+Scenario: Getting More Than 5 errors:
+    Given the following census observations response is available from Cantabular:
+       """
+       {
+        "dataset": {
+          "table": {
+            "dimensions": null
+            "error": "Maximum variables in query is 5",
+            "values": null
+          }
+        }
+       }
+       """
+    And census observations endpoint is enabled
+
+    When I GET "/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"
+    Then the HTTP status code should be "400"
+    Then I should receive the following JSON response:
+    """
+    {"errors": ["More than 5 variables selected, query failed"]}
+    """

--- a/features/census-observations.public.feature
+++ b/features/census-observations.public.feature
@@ -232,6 +232,8 @@ Given the following census observations response is available from Cantabular:
         }
     }
     """
+    
+    And the cantabular area response is bad request
 
     And census observations endpoint is enabled
 
@@ -245,7 +247,7 @@ Scenario: Getting More Than 5 errors:
        {
         "dataset": {
           "table": {
-            "dimensions": null
+            "dimensions": null,
             "error": "Maximum variables in query is 5",
             "values": null
           }

--- a/features/dimension-categories.public.feature
+++ b/features/dimension-categories.public.feature
@@ -59,6 +59,7 @@ Feature: Area Types
               "id": "sex",
               "label": "Sex (2 categories)",
               "quality_statement_text": "quality statement",
+              "default_categorisation": false,
               "categories": [
                   {
                       "id": "1",

--- a/features/mock/cantabular_client.go
+++ b/features/mock/cantabular_client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -34,6 +35,7 @@ type CantabularClient struct {
 	ListDatasetsResponse             *cantabular.ListDatasetsResponse
 	GetBlockedAreaCountResult        *cantabular.GetBlockedAreaCountResult
 	GetStaticDatasetQuery            *cantabular.StaticDatasetQuery
+	GetStaticDataset                 *gql.Dataset
 }
 
 func (c *CantabularClient) Checker(_ context.Context, _ *healthcheck.CheckState) error {
@@ -296,4 +298,8 @@ func (c *CantabularClient) StaticDatasetQuery(context.Context, cantabular.Static
 	}
 
 	return c.GetStaticDatasetQuery, nil
+}
+
+func (c *CantabularClient) StaticDatasetType(ctx context.Context, datasetName string) (*gql.Dataset, error) {
+	return c.GetStaticDataset, nil
 }

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cucumber/godog"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 )
 
 func (c *PopulationTypesComponent) RegisterSteps(ctx *godog.ScenarioContext) {
@@ -35,6 +36,7 @@ func (c *PopulationTypesComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the following base variable response is available from Cantabular:$`, c.theFollowingBaseVariableResponseIsAvailableFromCantabular)
 	ctx.Step(`^the following dimension categories response is available from Cantabular:$`, c.theFollowingDimensionCategoryResponseIsAvailableFromCantabular)
 	ctx.Step(`^the following census observations response is available from Cantabular:$`, c.theFollowingCensusObservationsResponseIsAvailableFromCantabular)
+	ctx.Step(`^the following dataset type is available from Cantabular:$`, c.theFollowingDatasetTypeIsAvailableFromCantabular)
 }
 
 func (c *PopulationTypesComponent) theFollowingDimensionCategoryResponseIsAvailableFromCantabular(body *godog.DocString) error {
@@ -256,4 +258,19 @@ func (c *PopulationTypesComponent) theFollowingCensusObservationsResponseIsAvail
 	c.fakeCantabular.GetStaticDatasetQuery = &resp
 	return nil
 
+}
+
+func (c *PopulationTypesComponent) theFollowingDatasetTypeIsAvailableFromCantabular(body *godog.DocString) error {
+	type dataset struct {
+		Dataset gql.Dataset `json:"dataset"`
+	}
+	type data struct {
+		Data dataset `json:"data"`
+	}
+	var resp data
+	if err := json.Unmarshal([]byte(body.Content), &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	c.fakeCantabular.GetStaticDataset = &resp.Data.Dataset
+	return nil
 }

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -253,10 +253,6 @@ func (c *PopulationTypesComponent) theFollowingCensusObservationsResponseIsAvail
 		return fmt.Errorf("failed to unmarshal body: %w", err)
 	}
 
-	if resp.Dataset.Table.Dimensions == nil {
-		c.fakeCantabular.BadRequest = true
-	}
-
 	c.fakeCantabular.GetStaticDatasetQuery = &resp
 	return nil
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.19
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.246.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0
 	github.com/ONSdigital/dp-component-test v0.9.0
@@ -25,7 +25,7 @@ require (
 	github.com/maxcnunes/httpfake v1.2.4
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.7.2
-	go.mongodb.org/mongo-driver v1.11.2
+	go.mongodb.org/mongo-driver v1.11.3
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 )
 
@@ -34,8 +34,8 @@ require (
 	github.com/ONSdigital/dp-mongodb-in-memory v1.5.0 // indirect
 	github.com/ONSdigital/dp-rchttp v1.0.0 // indirect
 	github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e // indirect
-	github.com/aws/aws-sdk-go v1.44.220 // indirect
-	github.com/chromedp/cdproto v0.0.0-20230310204135-a6d692f2c96d // indirect
+	github.com/aws/aws-sdk-go v1.44.227 // indirect
+	github.com/chromedp/cdproto v0.0.0-20230319112347-6603f2c23d36 // indirect
 	github.com/chromedp/chromedp v0.9.1 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
@@ -60,7 +60,7 @@ require (
 	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/montanaflynn/stats v0.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.19
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.240.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0
 	github.com/ONSdigital/dp-component-test v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.240.0 h1:h/BuXd+Y0wxFFGFrD3I9tRhJauRuKerEEoYzr8UkcO0=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.240.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0 h1:DnW4qakE3F8EAteZk0Hmhfg0sUAbNDvyMzT2XuKXyTA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0 h1:nkAboyjsFVM8AdPiHtfbMbBxRbAYcYJBDCmfTcFwWQw=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,10 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0 h1:DnW4qakE3F8EAteZk0Hmhfg0sUAbNDvyMzT2XuKXyTA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0 h1:h/BuXd+Y0wxFFGFrD3I9tRhJauRuKerEEoYzr8UkcO0=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.245.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.246.0 h1:udtjDrSKI5ZNbvoEkB+opD0GYva0I5a6sBDP3sAEyzY=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.246.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0 h1:nkAboyjsFVM8AdPiHtfbMbBxRbAYcYJBDCmfTcFwWQw=
@@ -96,10 +98,16 @@ github.com/ONSdigital/log.go/v2 v2.3.0 h1:go+KkUR36/CClez+UCCwVIVqFie1w3PYgvAyoc
 github.com/ONSdigital/log.go/v2 v2.3.0/go.mod h1:s5iqJuW0jDE8V7VQJqLHT73nn/H8u1c+A2Nqw2QPEeo=
 github.com/aws/aws-sdk-go v1.44.220 h1:yAj99qAt0Htjle9Up3DglgHfOP77lmFPrElA4jKnrBo=
 github.com/aws/aws-sdk-go v1.44.220/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.224 h1:09CiaaF35nRmxrzWZ2uRq5v6Ghg/d2RiPjZnSgtt+RQ=
+github.com/aws/aws-sdk-go v1.44.224/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.227 h1:HWNpINBu20yyfEXGHHSIsB955KUjWmZJETqnLIXizN4=
+github.com/aws/aws-sdk-go v1.44.227/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chromedp/cdproto v0.0.0-20230220211738-2b1ec77315c9/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/cdproto v0.0.0-20230310204135-a6d692f2c96d h1:V9DP/zVOBFANcxrhe1aHU1nknxHsn6wv9BEMyd/DQNY=
 github.com/chromedp/cdproto v0.0.0-20230310204135-a6d692f2c96d/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
+github.com/chromedp/cdproto v0.0.0-20230319112347-6603f2c23d36 h1:hwfwGvhqpEbMYO95KOphR/UP3Lh784Tckkg2RBn00tU=
+github.com/chromedp/cdproto v0.0.0-20230319112347-6603f2c23d36/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/chromedp v0.9.1 h1:CC7cC5p1BeLiiS2gfNNPwp3OaUxtRMBjfiw3E3k6dFA=
 github.com/chromedp/chromedp v0.9.1/go.mod h1:DUgZWRvYoEfgi66CgZ/9Yv+psgi+Sksy5DTScENWjaQ=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
@@ -286,6 +294,8 @@ github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/maxcnunes/httpfake v1.2.4 h1:l7s/N7zuG6XpzG+5dUolg5SSoR3hANQxqzAkv+lREko=
 github.com/maxcnunes/httpfake v1.2.4/go.mod h1:rWVxb0bLKtOUM/5hN3UO1VEdEitz1hfcTXs7UyiK6r0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -354,6 +364,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
 go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
+go.mongodb.org/mongo-driver v1.11.3 h1:Ql6K6qYHEzB6xvu4+AU0BoRoqf9vFPcc4o7MUIdPW8Y=
+go.mongodb.org/mongo-driver v1.11.3/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/handler/censusObservations.go
+++ b/handler/censusObservations.go
@@ -167,6 +167,18 @@ func (c *CensusObservations) Get(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
+	if len(qRes.Dataset.Table.Error) > 0 {
+		c.respond.Error(
+			ctx,
+			w,
+			http.StatusBadRequest,
+			Error{
+				err:     errors.New(handleError(CantabularError(qRes.Dataset.Table.Error))),
+				logData: logData,
+			},
+		)
+		return
+	}
 
 	response, err := c.toGetDatasetObservationsResponse(qRes)
 	if err != nil {
@@ -179,9 +191,10 @@ func (c *CensusObservations) Get(w http.ResponseWriter, r *http.Request) {
 				logData: logData,
 			},
 		)
-	} else {
-		//special handling for self link
-		response.Links.Self.HREF = r.URL.String()
-		c.respond.JSON(ctx, w, http.StatusOK, response)
 	}
+
+	//special handling for self link
+	response.Links.Self.HREF = r.URL.String()
+	c.respond.JSON(ctx, w, http.StatusOK, response)
+
 }

--- a/handler/dimensions.go
+++ b/handler/dimensions.go
@@ -376,11 +376,17 @@ func (h *Dimensions) GetCategorisations(w http.ResponseWriter, r *http.Request) 
 								})
 							}
 
+							defaultCategorisation := false
+							if isSourceOf.Node.Meta.DefaultClassification == "Y" {
+								defaultCategorisation = true
+							}
+
 							resp.Items = append(resp.Items, contract.Category{
-								Id:                   isSourceOf.Node.Name,
-								Label:                isSourceOf.Node.Label,
-								QualityStatementText: isSourceOf.Node.Meta.ONSVariable.QualityStatementText,
-								Categories:           cats,
+								Id:                    isSourceOf.Node.Name,
+								Label:                 isSourceOf.Node.Label,
+								QualityStatementText:  isSourceOf.Node.Meta.ONSVariable.QualityStatementText,
+								Categories:            cats,
+								DefaultCategorisation: defaultCategorisation,
 							})
 						}
 					}
@@ -398,11 +404,17 @@ func (h *Dimensions) GetCategorisations(w http.ResponseWriter, r *http.Request) 
 						})
 					}
 
+					defaultCategorisation := false
+					if sourceOf.Node.Meta.DefaultClassification == "Y" {
+						defaultCategorisation = true
+					}
+
 					resp.Items = append(resp.Items, contract.Category{
-						Id:                   sourceOf.Node.Name,
-						Label:                sourceOf.Node.Label,
-						QualityStatementText: sourceOf.Node.Meta.ONSVariable.QualityStatementText,
-						Categories:           cats,
+						Id:                    sourceOf.Node.Name,
+						Label:                 sourceOf.Node.Label,
+						QualityStatementText:  sourceOf.Node.Meta.ONSVariable.QualityStatementText,
+						DefaultCategorisation: defaultCategorisation,
+						Categories:            cats,
 					})
 				}
 			}

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-population-types-api/datastore"
@@ -30,6 +31,7 @@ type cantabularClient interface {
 	GetBaseVariable(context.Context, cantabular.GetBaseVariableRequest) (*cantabular.GetBaseVariableResponse, error)
 	StatusCode(error) int
 	StaticDatasetQuery(context.Context, cantabular.StaticDatasetQueryRequest) (*cantabular.StaticDatasetQuery, error)
+	StaticDatasetType(ctx context.Context, datasetName string) (*gql.Dataset, error)
 }
 
 type datasetAPIClient interface {

--- a/handler/utils.go
+++ b/handler/utils.go
@@ -18,3 +18,19 @@ func filterPopulationTypes(coundition []string, toFilter []contract.PopulationTy
 
 	return filtered
 }
+
+type CantabularError string
+
+const (
+	MaxVariableError        = "Maximum variables at MSOA and above is 5"
+	MaxVariableGraphqlError = "Maximum variables in query is 5"
+)
+
+func handleError(errString CantabularError) string {
+	switch errString {
+	case MaxVariableError, MaxVariableGraphqlError:
+		return "More than 5 variables selected, query failed"
+	default:
+		return "Unexpected error"
+	}
+}

--- a/service/interface.go
+++ b/service/interface.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-population-types-api/config"
@@ -60,6 +61,7 @@ type CantabularClient interface {
 	CheckerAPIExt(ctx context.Context, state *healthcheck.CheckState) error
 	StatusCode(error) int
 	StaticDatasetQuery(context.Context, cantabular.StaticDatasetQueryRequest) (*cantabular.StaticDatasetQuery, error)
+	StaticDatasetType(ctx context.Context, datasetName string) (*gql.Dataset, error)
 }
 
 // Responder handles responding to http requests

--- a/service/mock/cantabular_client.go
+++ b/service/mock/cantabular_client.go
@@ -6,6 +6,7 @@ package mock
 import (
 	"context"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-population-types-api/service"
 	"sync"
@@ -69,6 +70,9 @@ var _ service.CantabularClient = &CantabularClientMock{}
 //			StaticDatasetQueryFunc: func(contextMoqParam context.Context, staticDatasetQueryRequest cantabular.StaticDatasetQueryRequest) (*cantabular.StaticDatasetQuery, error) {
 //				panic("mock out the StaticDatasetQuery method")
 //			},
+//			StaticDatasetTypeFunc: func(ctx context.Context, datasetName string) (*gql.Dataset, error) {
+//				panic("mock out the StaticDatasetType method")
+//			},
 //			StatusCodeFunc: func(err error) int {
 //				panic("mock out the StatusCode method")
 //			},
@@ -126,6 +130,9 @@ type CantabularClientMock struct {
 
 	// StaticDatasetQueryFunc mocks the StaticDatasetQuery method.
 	StaticDatasetQueryFunc func(contextMoqParam context.Context, staticDatasetQueryRequest cantabular.StaticDatasetQueryRequest) (*cantabular.StaticDatasetQuery, error)
+
+	// StaticDatasetTypeFunc mocks the StaticDatasetType method.
+	StaticDatasetTypeFunc func(ctx context.Context, datasetName string) (*gql.Dataset, error)
 
 	// StatusCodeFunc mocks the StatusCode method.
 	StatusCodeFunc func(err error) int
@@ -242,6 +249,13 @@ type CantabularClientMock struct {
 			// StaticDatasetQueryRequest is the staticDatasetQueryRequest argument value.
 			StaticDatasetQueryRequest cantabular.StaticDatasetQueryRequest
 		}
+		// StaticDatasetType holds details about calls to the StaticDatasetType method.
+		StaticDatasetType []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// DatasetName is the datasetName argument value.
+			DatasetName string
+		}
 		// StatusCode holds details about calls to the StatusCode method.
 		StatusCode []struct {
 			// Err is the err argument value.
@@ -264,6 +278,7 @@ type CantabularClientMock struct {
 	lockGetParents               sync.RWMutex
 	lockListDatasets             sync.RWMutex
 	lockStaticDatasetQuery       sync.RWMutex
+	lockStaticDatasetType        sync.RWMutex
 	lockStatusCode               sync.RWMutex
 }
 
@@ -836,6 +851,42 @@ func (mock *CantabularClientMock) StaticDatasetQueryCalls() []struct {
 	mock.lockStaticDatasetQuery.RLock()
 	calls = mock.calls.StaticDatasetQuery
 	mock.lockStaticDatasetQuery.RUnlock()
+	return calls
+}
+
+// StaticDatasetType calls StaticDatasetTypeFunc.
+func (mock *CantabularClientMock) StaticDatasetType(ctx context.Context, datasetName string) (*gql.Dataset, error) {
+	if mock.StaticDatasetTypeFunc == nil {
+		panic("CantabularClientMock.StaticDatasetTypeFunc: method is nil but CantabularClient.StaticDatasetType was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		DatasetName string
+	}{
+		Ctx:         ctx,
+		DatasetName: datasetName,
+	}
+	mock.lockStaticDatasetType.Lock()
+	mock.calls.StaticDatasetType = append(mock.calls.StaticDatasetType, callInfo)
+	mock.lockStaticDatasetType.Unlock()
+	return mock.StaticDatasetTypeFunc(ctx, datasetName)
+}
+
+// StaticDatasetTypeCalls gets all the calls that were made to StaticDatasetType.
+// Check the length with:
+//
+//	len(mockedCantabularClient.StaticDatasetTypeCalls())
+func (mock *CantabularClientMock) StaticDatasetTypeCalls() []struct {
+	Ctx         context.Context
+	DatasetName string
+} {
+	var calls []struct {
+		Ctx         context.Context
+		DatasetName string
+	}
+	mock.lockStaticDatasetType.RLock()
+	calls = mock.calls.StaticDatasetType
+	mock.lockStaticDatasetType.RUnlock()
 	return calls
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -754,6 +754,8 @@ definitions:
               $ref: '#/definitions/Category'
           total_count:
             type: integer
+          default_categorisation:
+            type: boolean
   DimensionCategory:
     description: "The response body containing the information for a dimension category"
     properties:
@@ -791,3 +793,19 @@ definitions:
       id:
         type: string
         description: "id of resource"
+  ObservationDimension:
+    type: object
+    description: "A dimension returned relating to an observation"
+    properties:
+      dimension:
+        type: string
+        description: "The dimension description"
+      dimension_id:
+        type: string
+        description: "The dimension id"
+      option:
+        type: string
+        description: "The description of the option the observation relates to"
+      option_id:
+        type: string
+        description: "The id of the option the observation relates to"


### PR DESCRIPTION
### What

Release 1.26.0
- Added default categorisation flag to get categorisations
- Added error handling to census-outputs endpoint

### How to review

Ensure the changes make sense.

### Who can review

Anyone who hasn't added work to the release.