### PR TITLE
added support for rules count

### DIFF
--- a/features/census-observations.public.feature
+++ b/features/census-observations.public.feature
@@ -83,6 +83,17 @@ Scenario: Getting census observations successfully
                     }
                 ],
                 "error": null,
+                "rules": {
+                    "blocked": {
+                        "count": 0
+                    },
+                    "evaluated": {
+                        "count": 1
+                    },
+                    "passed": {
+                        "count": 1
+                    }
+                },
                 "values": [
                     57326,
                     4376,
@@ -227,7 +238,10 @@ Scenario: Getting census observations successfully
                 "href": "http://foo/population-types/UR/census-observations?dimensions=ltla,resident_age_7b&area-type=ltla,E06000001"
             }
         },
-        "total_observations": 7
+        "total_observations": 7,
+        "blocked_areas": 0,
+        "total_areas": 1,
+        "areas_returned": 1
     }
     """
 

--- a/handler/censusObservations.go
+++ b/handler/censusObservations.go
@@ -27,6 +27,9 @@ type GetObservationsResponse struct {
 	Observations      []GetObservationResponse `bson:"observations"           json:"observations"`
 	Links             DatasetJSONLinks         `json:"links"`
 	TotalObservations int                      `json:"total_observations"`
+	BlockedAreas      int                      `json:"blocked_areas"`
+	TotalAreas        int                      `json:"total_areas"`
+	AreasReturned     int                      `json:"areas_returned"`
 }
 
 type ObservationDimension struct {
@@ -109,6 +112,10 @@ func (c *CensusObservations) toGetDatasetObservationsResponse(query *cantabular.
 	var getObservationsResponse GetObservationsResponse
 	getObservationsResponse.Observations = getObservationResponse
 	getObservationsResponse.TotalObservations = len(query.Dataset.Table.Values)
+
+	getObservationsResponse.BlockedAreas = query.Dataset.Table.Rules.Blocked.Count
+	getObservationsResponse.TotalAreas = query.Dataset.Table.Rules.Total.Count
+	getObservationsResponse.AreasReturned = query.Dataset.Table.Rules.Total.Count
 
 	return &getObservationsResponse, nil
 }


### PR DESCRIPTION
### What
Ticket: https://trello.com/c/CyodKOVq/6078-implement-blocked-area-count-in-census-observations-population-types-api
Added rules count to the census observation response
### How to review

All test are :green_circle: 

### Who can review

Anyone
