### PR TITLE
Release/1.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.19
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.248.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.249.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0
 	github.com/ONSdigital/dp-component-test v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.248.1 h1:Qu35Z8UMcgKT2vFiQ3GdWH8wJgrMwujyqg268VKfOlw=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.248.1/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.249.0 h1:dOU5dhVUIoUeyc302gqfiAEGvAbFVdYDx6jsGHomDUs=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.249.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-cantabular-filter-flex-api v1.19.0 h1:nkAboyjsFVM8AdPiHtfbMbBxRbAYcYJBDCmfTcFwWQw=

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -132,8 +132,6 @@ paths:
   /population-types/{population-type}/dimensions:
     get:
       summary: "Get list of non-geography base variables for given dataset "
-      tags:
-        - "Private"
       description: ""
       produces:
         - "application/json"
@@ -222,8 +220,6 @@ paths:
   /population-types/{population-type}/dimensions/{dimension}/categorisations:
     get:
       summary: "Get list of categorisations for a base level variable"
-      tags:
-        - "Private"
       description: ""
       produces:
         - "application/json"


### PR DESCRIPTION
### What

Release 1.28.0
- Reinstating SDC queries for census-outputs endpoint
- Updates to swagger spec for developer hub

### How to review

Ensure the changes make sense.

### Who can review

Anyone.
